### PR TITLE
make sure to update the data before stopping the state machine

### DIFF
--- a/lib/states_language/ast/await.ex
+++ b/lib/states_language/ast/await.ex
@@ -29,11 +29,12 @@ defmodule StatesLanguage.AST.Await do
              _ -> false
            end) do
           res = Enum.map(tasks, fn {_p, res} -> res end)
+          Logger.info("All tasks complete: #{inspect(res)}")
           data = put_result(res, unquote(resource_path), unquote(output_path), data)
 
           case AST.do_stop?(unquote(is_end)) do
             true ->
-              :stop
+              {:stop, :end, %StatesLanguage{sl | data: data}}
 
             false ->
               {:keep_state, %StatesLanguage{sl | data: data, _tasks: []},

--- a/lib/states_language/ast/task.ex
+++ b/lib/states_language/ast/task.ex
@@ -33,7 +33,7 @@ defmodule StatesLanguage.AST.Task do
 
         case AST.do_stop?(unquote(is_end)) do
           true ->
-            :stop
+            {:stop, :end, %StatesLanguage{sl | data: data}}
 
           false ->
             {:keep_state, %StatesLanguage{sl | data: data}, actions}

--- a/test/support/test_client_map_first.ex
+++ b/test/support/test_client_map_first.ex
@@ -5,10 +5,11 @@ defmodule StatesLanguage.TestClientMap.First do
   require Logger
 
   @impl true
-  def handle_resource("MapResource", item, "MapFirst", %StatesLanguage{data: _data} = sl) do
+  def handle_resource("MapResource", item, "MapFirst", %StatesLanguage{data: data} = sl) do
     item = %{item | data: item.data + 10}
     send(sl._parent_data.test, {:map, item.data})
-    {:ok, %StatesLanguage{sl | data: item}, []}
+    sl = %StatesLanguage{sl | data: item}
+    {:ok, sl, [{:next_event, :internal, :transition}]}
   end
 
   @impl true
@@ -24,8 +25,13 @@ defmodule StatesLanguage.TestClientMap.First do
   end
 
   @impl true
-  def handle_termination(_, _, %StatesLanguage{data: data} = sl) do
-    debug("Sending Parent Result #{inspect(data)} from #{inspect(self())}")
+  def handle_termination(reason, state, %StatesLanguage{data: data} = sl) do
+    debug(
+      "Sending Parent Result in #{state} with reason #{reason} #{inspect(sl)} from #{
+        inspect(self())
+      }"
+    )
+
     send(sl._parent, {:task_processed, data, self()})
     :ok
   end


### PR DESCRIPTION
There was a bug where if a state was marked as `"End": true` it would not capture the result of the `Resource` callback. This fixes the issue.